### PR TITLE
Verify for LDFLAGS during compilation time

### DIFF
--- a/container/etc/portage/make.conf
+++ b/container/etc/portage/make.conf
@@ -2,7 +2,7 @@ ACCEPT_KEYWORDS="~amd64"
 
 CFLAGS="-march=native -O2 -pipe"
 CXXFLAGS="${CFLAGS}"
-#LDFLAGS="${LDFLAGS}"
+LDFLAGS="${LDFLAGS} -Wl,--defsym=__gentoo_check_ldflags__=0"
 FFLAGS="${CFLAGS}"
 FCFLAGS="${CFLAGS}"
 


### PR DESCRIPTION
Hi, this change can help on checking LDFLAGS QA notice, I think it can be useful during installation

Signed-off-by: Marco Scardovi <scardracs-gentoo@proton.me>