### PR TITLE
remove '.editorconfig' before attempting to clone ::gentoo

### DIFF
--- a/container/bin/initialize_my-test-container.sh
+++ b/container/bin/initialize_my-test-container.sh
@@ -65,6 +65,7 @@ sleep 5
 rm -r /var/db/repos/gentoo/* || exit
 rm -rf /var/db/repos/gentoo/.git || return
 rm -f /var/db/repos/gentoo/.gitignore || return
+rm -f /var/db/repos/gentoo/.editorconfig || return
 emerge --sync || exit
 
 echo ""


### PR DESCRIPTION
3f460fbebaf8f2acaf1a7b132d1eb97f089c1a13 added a new dotfile to ::gentoo. Consequently, cloning the repository fails because the destination path /var/db/repos/gentoo is not empty.