### PR TITLE
Improve readability of container/bin/prtester.sh

### DIFF
--- a/container/bin/prtester.sh
+++ b/container/bin/prtester.sh
@@ -32,7 +32,7 @@ pkg-testing-tool --append-emerge '--autounmask=y --oneshot' \
 	--extra-env-file 'test.conf' \
 	--test-feature-scope once --max-use-combinations 6 \
 	--report /var/tmp/portage/vbslogs/"${commit}".json \
-	"${pkgstobetested[@]/#/-f }"
+	"${pkgstobetested[@]/#/-f}"
 
 echo "Error reports for failed atoms, use errors_and_qa_notices.sh to find out exact errors:"
 # Print previous line after a pattern match using sed: https://unix.stackexchange.com/a/206887

--- a/container/bin/prtester.sh
+++ b/container/bin/prtester.sh
@@ -11,40 +11,30 @@
 
 cd /var/db/repos/gentoo || exit
 
-# Create an array of commits
-mapfile -t newcommits < <(git rev-list origin/HEAD..HEAD)
-declare -a pkgstobetestedtmp1
-declare -a pkgstobetestedfinalarray
-
-if [[ ${#newcommits[@]} -eq 0 ]]; then
+# git rev-list --quiet doesn't seem to work as intended (v2.44.1)
+if [[ -z "$(git rev-list origin/HEAD..HEAD)" ]]; then
 	echo "Couldn't find new commits to test. Exiting..."
 	exit
 fi
 
-# Please send help with the grepping...
-# /^[+-]{3} [a-z]\/([^\/]+)\/[^\/]+\/(.*)\.ebuild/
-# | grep -E '\+\+\+' | grep ".ebuild" | cut -d  "/" -f 2,4 | awk -F  '.ebuild' '{print $1}'
-# | grep -E '^[+]{3} [a-z]/([^\/]+)/[^\/]+/(.*)\.ebuild$' | sed 's#^[+-]\{3\} [a-z]/ \([^/]\+\)/[^/]\+/\(.*\)\.ebuild#\1/\2#'
-for i in "${newcommits[@]}"; do
-	pkgstobetestedtmp1+=( $(git show "${i}" | grep -E '^[+]{3} [a-z]/([^\/]+)/[^\/]+/(.*)\.ebuild$' | sed 's#^[+]\{3\} [a-z]/\([^/]\+\)/[^/]\+/\(.*\)\.ebuild#\1/\2#') )
-	pkgstobetestedtmp1+=( $(git show "${i}" | grep "rename to" | grep ".ebuild" | cut -d " " -f3 | cut -d  "/" -f 1,3 | awk -F  '.ebuild' '{print $1}') )
-done
-
-# Remove any duplicate entries, we only need to test the final ebuild once.
-declare -A tmpsortarray
-for i in "${pkgstobetestedtmp1[@]}"; do tmpsortarray["${i}"]=1; done
-mapfile -t pkgstobetestedfinalarray < <(printf '%s\n' "${!tmpsortarray[@]}")
+pkgstobetested=(
+	$(git show --name-only --diff-filter=AMR --format=tformat: \
+	origin/HEAD..HEAD | sort -u | grep ebuild)
+)
 
 # Let's print what we're about to test.
-echo "Packages to be tested:"
-echo "${pkgstobetestedfinalarray[@]}"
+echo "Ebuilds to be tested:"
+echo "${pkgstobetested[@]}"
 echo ""
 
-for (( j=0; j<${#pkgstobetestedfinalarray[@]}; j++ )); do
-	atom=$(echo "${pkgstobetestedfinalarray[${j}]}" | cut -d  "/" -f 2)
-	pkg-testing-tool --append-emerge '--autounmask=y --oneshot' --extra-env-file 'test.conf' \
-		--test-feature-scope once --max-use-combinations 6 --report /var/tmp/portage/vbslogs/"${atom}"-"${j}".json \
-		-p "=${pkgstobetestedfinalarray[${j}]}"
+for pkg in "${pkgstobetested[@]}"; do
+	atom="${pkg##*/}"
+	atom="${atom%.ebuild}"
+	pkg-testing-tool --append-emerge '--autounmask=y --oneshot' \
+		--extra-env-file 'test.conf' \
+		--test-feature-scope once --max-use-combinations 6 \
+		--report /var/tmp/portage/vbslogs/"${atom}".json \
+		-f "${pkg}"
 done
 
 echo "Error reports for failed atoms, use errors_and_qa_notices.sh to find out exact errors:"

--- a/container/bin/prtester.sh
+++ b/container/bin/prtester.sh
@@ -24,7 +24,7 @@ pkgstobetested=(
 
 # Let's print what we're about to test.
 echo "Ebuilds to be tested:"
-echo "${pkgstobetested[@]}"
+printf "%s\n" "${pkgstobetested[@]}"
 echo ""
 
 commit="$(git rev-parse --short=8 HEAD)"


### PR DESCRIPTION
To simplify identifying ebuilds for testing, the new code makes use of git's ability to:
- `show` multiple commits with one invocation
 We can avoid an unnecessary for loop this way.
- narrow down the output to certain types of changes
 Possible types are:
  > Files that are Added (A), Copied (C), Deleted (D), Modified (M), Renamed (R),
           have their type (i.e. regular file, symlink, submodule, ...) changed (T), are Unmerged (U),
           are Unknown (X), or have had their pairing Broken (B)
           
  I considered also scanning for copied files (if `diff.renames` is set to `copies` or `copy`), but I couldn't recreate any examples, where the changes weren't picked up by `R`.
- format the log such that everything except the diffs (commits are separated by `\n`) is omitted.
 Further boil down the output by only showing the names of changed files. This makes grepping for ebuilds easy.

I also dropped the second loop in favor of passing the ebuilds to `pkg-testing-tool` all at once. The newly unified testing report is  now identified by the commit hash of  `HEAD`. That's not too descriptive but I couldn't think of a suitable alternative.