### PR TITLE
container/bin/prtester.sh: filter deleted ebuilds from `pkgstobetested`

### DIFF
--- a/container/bin/prtester.sh
+++ b/container/bin/prtester.sh
@@ -17,10 +17,12 @@ if [[ -z "$(git rev-list origin/HEAD..HEAD)" ]]; then
 	exit
 fi
 
-pkgstobetested=(
-	$(git show --name-only --diff-filter=AMR --format=tformat: \
-	origin/HEAD..HEAD | sort -u | grep ebuild)
-)
+candidates="$(git show --name-only --diff-filter=AMR --format=tformat: \
+	origin/HEAD..HEAD | sort -u | grep ebuild)"
+pkgstobetested=()
+for ebuild in ${candidates}; do
+	[[ -f "${ebuild}" ]] && pkgstobetested+=("${ebuild}")
+done
 
 # Let's print what we're about to test.
 echo "Ebuilds to be tested:"


### PR DESCRIPTION
Ebuilds that have been created/modified within `origin/HEAD..HEAD` may not exist at `HEAD` anymore. `prtester.sh` erroneously selects these files for testing, which causes `pkg-testing-tool` to crash:
```sh
cd /var/db/repos/gentoo
mkdir -p app-misc/testpkg
touch app-misc/testpkg/testpkg-1.ebuild && git add app-misc/testpkg/
git commit -m "app-misc/testpkg: new package"
echo modification > app-misc/testpkg/testpkg-1.ebuild && git add app-misc/testpkg/
git commit -m "app-misc/testpkg: picked up because of --diff-filter=M"
git mv app-misc/testpkg/testpkg-1{,-r1}.ebuild
git commit -m "app-misc/testpkg: picked up because of --diff-filter=R"
prtester.sh
```